### PR TITLE
standardized closing script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
 				<p class="footer-copyright">Text released under <a href="http://creativecommons.org/licenses/by/4.0/">the Creative Commons Attribution 4.0 International (CC-BY) license</a>. HTML, CSS, images, and design are based on a design <a href="https://github.com/sudomesh/peoplesopen-front">forked from PeoplesOpen.Net</a> which was, in turn, forked from <a href="http://martini.codegangsta.io/">Martini’s template</a>, reused here under the MIT License. <a href="http://www.flickr.com/photos/tostie14/117610830/">Aerial photo of Boston</a> is by Kevin Tostado, reused under a <a href="http://creativecommons.org/licenses/by-nc/2.0/">CC-A-NC 2.0</a> license</p>
 			</div>
 			<!-- /END: Copyright Notice -->
-			<script src="http://theodi.org/nodes/usa/badge.js" />
+			<script src="http://theodi.org/nodes/usa/badge.js"></script>
 		</div>
 	</footer>
 	<!-- /END: Site Footer -->


### PR DESCRIPTION
The embed script for the ODI Node badge used a shorthand <script /> tag, which upsets GitHub syntax coloring.

Noticed this while looking for the broken link in the badge itself, which is pulled in from http://theodi.org/nodes/usa/badge.js
