### PR TITLE
heading shadow for readability

### DIFF
--- a/css/gumby.css
+++ b/css/gumby.css
@@ -8990,6 +8990,7 @@ input::-moz-focus-inner {
   width: 100%;
   color: #fff;
   border-top: 5px solid #20b24b;
+  text-shadow: 0 2px 2px rgba(0,0,0,0.6);
 }
 
 .logo {

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 						</span>
 					</span>		
 					<h3>Partnering with Gov’t</h3>
-					<p>We love government. We’re collaborating with local, state, and federal agencies, at no cost to them, to help them release data sets and promote their work.</p>
+					<p>We love government. We’re collaborating with local, state, and federal agencies (at no cost to them) to help them release data sets and promote their work.</p>
 				</li>
 				<!-- /END: Feature Item -->
 				<!-- START: Feature Item -->


### PR DESCRIPTION
added a text-shadow to the heading for readability and adjusted a
sentence to reduce the comma splicing.
