### PR TITLE
add a basic rss feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 markdown: kramdown
+name: U.S. Open Data Institute
+url: http://usodi.org

--- a/_includes/top.html
+++ b/_includes/top.html
@@ -24,4 +24,6 @@
 
 	<!-- Load Modenizr for feature detection FIRST. -->
 	<script src="/js/libs/modernizr-2.6.2.min.js"></script>
+
+	<link rel="alternate" type="application/rss+xml" title="{{ site.name }} RSS" href="/rss.xml" />
 </head>

--- a/rss.xml
+++ b/rss.xml
@@ -1,0 +1,21 @@
+---
+layout: none
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+	<channel>
+		<title>{{ site.name | xml_escape }}</title>
+		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>		
+		<link>{{ site.url }}</link>
+		<atom:link href="{{ site.url }}/rss.xml" rel="self" type="application/rss+xml" />
+		{% for post in site.posts limit:10 %}
+			<item>
+				<title>{{ post.title | xml_escape }}</title>
+				<description>{{ post.content | xml_escape }}</description>
+				<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+				<link>{{ site.url }}{{ post.url }}</link>
+				<guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+			</item>
+		{% endfor %}
+	</channel>
+</rss>


### PR DESCRIPTION
I was looking for an RSS feed for the USODI blog. Hope you'd be willing to add one. This PR adds a basic RSS feed following https://github.com/snaptortoise/jekyll-rss-feeds.
