### PR TITLE
updated legacy github repo link

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 						</span>
 					</span>		
 					<h3>Creating Reusable Code</h3>			
-					<p>Before we even had a website, we had <a href="https://github.com/usodi/">a GitHub repository</a>. We’re creating, supporting, and <a href="/blog/">promoting</a> software essential to the open data ecosystem.</p>
+					<p>Before we even had a website, we had <a href="https://github.com/opendata/">a GitHub repository</a>. We’re creating, supporting, and <a href="/blog/">promoting</a> software essential to the open data ecosystem.</p>
 				</li>
 				<!-- /END: Feature Item -->
 			</ul>


### PR DESCRIPTION
Updated legacy /usodi link which yielded 404 on github. Other links with usodi path linking to a specific repo still redirect properly.
